### PR TITLE
sync höfer lab RPBPBR

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ RPBPBR <input.fasta/fastq> <out.prefix> <type|fasta/fastq> [keep-temp]
 Xi Wang (xi dot wang at dkfz dot de)
 
 ## Citation
-[1] Weike Pei, Thorsten B. Feyerabend, Jens Roessler, Xi Wang, Daniel Postrach, Katrin Busch, Immanuel Rode, Kay Klapproth, Nikolaus Dietlein, Claudia Quedenau, Wei Chen, Sascha Sauer, Stephan Wolf, Thomas Hoefer, and Hans-Reimer Rodewald. (2017) **_Polylox_ barcoding reveals hematopoietic stem cell fates realized in vivo**. *Nature*, 548, 456-460.
+[1] Weike Pei, Thorsten B. Feyerabend, Jens Roessler, Xi Wang, Daniel Postrach, Katrin Busch, Immanuel Rode, Kay Klapproth, Nikolaus Dietlein, Claudia Quedenau, Wei Chen, Sascha Sauer, Stephan Wolf, Thomas Hoefer, and Hans-Reimer Rodewald. (2017) **_Polylox_ barcoding reveals hematopoietic stem cell fates realized in vivo**. *Nature*, **548**, 456-460.
 
 

--- a/README.md
+++ b/README.md
@@ -14,5 +14,7 @@ Xi Wang (xi dot wang at dkfz dot de)
 
 ## Citation
 [1] Weike Pei, Thorsten B. Feyerabend, Jens Roessler, Xi Wang, Daniel Postrach, Katrin Busch, Immanuel Rode, Kay Klapproth, Nikolaus Dietlein, Claudia Quedenau, Wei Chen, Sascha Sauer, Stephan Wolf, Thomas Hoefer, and Hans-Reimer Rodewald. (2017) **_Polylox_ barcoding reveals hematopoietic stem cell fates realized in vivo**. *Nature*, **548**, 456-460.
-[2] Weike Pei*, Xi Wang*, Jens Rössler*, Thorsten B Feyerabend, Thomas Höfer, Hans-Reimer Rodewald. (2019) **_Using Cre-recombinase-driven Polylox barcoding for in vivo fate mapping in mice**_. *Nat Protoc*, **14**, 1820–1840. doi:10.1038/s41596-019-0163-5
+
+
+[2] Weike Pei*, Xi Wang*, Jens Rössler*, Thorsten B Feyerabend, Thomas Höfer, Hans-Reimer Rodewald. (2019) **Using Cre-recombinase-driven _Polylox_ barcoding for in vivo fate mapping in mice**. *Nat Protoc*, **14**, 1820–1840. doi:10.1038/s41596-019-0163-5
 

--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ Xi Wang (xi dot wang at dkfz dot de)
 
 ## Citation
 [1] Weike Pei, Thorsten B. Feyerabend, Jens Roessler, Xi Wang, Daniel Postrach, Katrin Busch, Immanuel Rode, Kay Klapproth, Nikolaus Dietlein, Claudia Quedenau, Wei Chen, Sascha Sauer, Stephan Wolf, Thomas Hoefer, and Hans-Reimer Rodewald. (2017) **_Polylox_ barcoding reveals hematopoietic stem cell fates realized in vivo**. *Nature*, **548**, 456-460.
-
+[2] Weike Pei*, Xi Wang*, Jens Rössler*, Thorsten B Feyerabend, Thomas Höfer, Hans-Reimer Rodewald. (2019) **_Using Cre-recombinase-driven Polylox barcoding for in vivo fate mapping in mice**_. *Nat Protoc*, **14**, 1820–1840. doi:10.1038/s41596-019-0163-5
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RPBPBR <input.fasta/fastq> <out.prefix> <type|fasta/fastq> [keep-temp]
 
 
 ## Contact
-Xi Wang (xi dot wang at dkfz dot de)
+Xi Wang (xi dot wang at dkfz dot de) OR (xiwang at njmu dot edu dot cn)
 
 ## Citation
 [1] Weike Pei, Thorsten B. Feyerabend, Jens Roessler, Xi Wang, Daniel Postrach, Katrin Busch, Immanuel Rode, Kay Klapproth, Nikolaus Dietlein, Claudia Quedenau, Wei Chen, Sascha Sauer, Stephan Wolf, Thomas Hoefer, and Hans-Reimer Rodewald. (2017) **_Polylox_ barcoding reveals hematopoietic stem cell fates realized in vivo**. *Nature*, **548**, 456-460.

--- a/bin/RPBPBR
+++ b/bin/RPBPBR
@@ -117,7 +117,7 @@ samtools view -F 4 -h ${OUTPRE}_clean.segements.bam | parse_seg_map.pl /dev/stdi
 grep '>' ${OUTPRE}.145_remain.fa | wc -l > ${OUTPRE}.stat
 grep '>' ${OUTPRE}_clean.fa | wc -l >> ${OUTPRE}.stat
 cut -f2 ${OUTPRE}.seg_assemble.txt | sort | uniq -c | awk -v OFS='\t' '{print $1,$2}' | sort -k1,1nr >> ${OUTPRE}.stat
-awk -v OFS='\t' '{if(NR==1){print "total",$1} if(NR==2) {print "intact",$1} if(NR>2) {print $2,$1}}' ${OUTPRE}.stat > ../${OUTPRE}.barcode.count.tsv
+awk -v OFS='\t' '{if(NR==1){print "total",$1} if(NR==2) {print "intact",$1} if(NR>2) {print "'\''"$2"'\''",$1}}' ${OUTPRE}.stat > ../${OUTPRE}.barcode.count.tsv
 
 ### rm temp dir by default
 if (( $KEEPTMP == 0 )); then 

--- a/bin/RPBPBR
+++ b/bin/RPBPBR
@@ -116,8 +116,8 @@ echo "STEP 3: barcode assembly..."
 samtools view -F 4 -h ${OUTPRE}_clean.segements.bam | parse_seg_map.pl /dev/stdin ${OUTPRE}.seg_assemble.txt
 grep '>' ${OUTPRE}.145_remain.fa | wc -l > ${OUTPRE}.stat
 grep '>' ${OUTPRE}_clean.fa | wc -l >> ${OUTPRE}.stat
-cut -f2 ${OUTPRE}.seg_assemble.txt | sort | uniq -c | awk -vOFS='\t' '{print $1,$2}' | sort -k1,1nr >> ${OUTPRE}.stat
-awk -vOFS='\t' '{if(NR==1){print "total",$1} if(NR==2) {print "intact",$1} if(NR>2) {print $2,$1}}' ${OUTPRE}.stat > ../${OUTPRE}.barcode.count.tsv
+cut -f2 ${OUTPRE}.seg_assemble.txt | sort | uniq -c | awk -v OFS='\t' '{print $1,$2}' | sort -k1,1nr >> ${OUTPRE}.stat
+awk -v OFS='\t' '{if(NR==1){print "total",$1} if(NR==2) {print "intact",$1} if(NR>2) {print $2,$1}}' ${OUTPRE}.stat > ../${OUTPRE}.barcode.count.tsv
 
 ### rm temp dir by default
 if (( $KEEPTMP == 0 )); then 

--- a/bin/RPBPBR
+++ b/bin/RPBPBR
@@ -23,6 +23,21 @@ exe_file()
   fi
 }
 
+location() 
+{
+  TF=$@
+  while [ -L "$TF" ] ; do
+    TF=`readlink $TF`
+  done
+  CUR=`pwd`
+  cd `dirname $TF`
+  TF=`basename $TF`
+  DIR=`pwd -P`
+  cd $CUR
+  FULL=$DIR/$TF
+  echo $FULL
+}
+
 if (( $# < 3 )); then
   err "USAGE: $0 <input.fasta/fastq> <out_prefix> <type:fasta/fastq> [keep temp]"
   exit 1;
@@ -52,7 +67,12 @@ if (( $# == 4 )); then
   KEEPTMP=1 
 fi
 
-FILE=`readlink -f $0`
+if [ `uname` = 'Darwin' ]; then
+  FILE=`location $0`
+else
+  FILE=`readlink -f $0`
+fi
+
 BIN=`dirname $FILE`
 DATA=$BIN/../data/
 PATH=$BIN:$PATH

--- a/bin/RPBPBR
+++ b/bin/RPBPBR
@@ -93,7 +93,7 @@ bowtie2 -f --very-sensitive --score-min L,-1.6,-1.6 --mp 5 --rdg 4,2 --rfg 4,2 -
 
 echo "STEP 3: barcode assembly..."
 
-samtools view -h ${OUTPRE}_clean.segements.bam | parse_seg_map.pl /dev/stdin ${OUTPRE}.seg_assemble.txt
+samtools view -F 4 -h ${OUTPRE}_clean.segements.bam | parse_seg_map.pl /dev/stdin ${OUTPRE}.seg_assemble.txt
 grep '>' ${OUTPRE}.145_remain.fa | wc -l > ${OUTPRE}.stat
 grep '>' ${OUTPRE}_clean.fa | wc -l >> ${OUTPRE}.stat
 cut -f2 ${OUTPRE}.seg_assemble.txt | sort | uniq -c | awk -vOFS='\t' '{print $1,$2}' | sort -k1,1nr >> ${OUTPRE}.stat


### PR DESCRIPTION
the current RPBPBR on höfer-lab GitHub is outdated, as it is missing the quotation marks around the barcodes from [df67137](https://github.com/hoefer-lab/RPBPBR/pull/4/commits/df671370e9566996bfd3ce3edee078c131084c98). Everything else in the bin folder is identical. Github just seems a bit confused in how to integrate the changes. Should be possible without conflicts, but somehow requires a pull request like this.